### PR TITLE
Fix ELF loading crashes and unresolved imports for stripped/retail binaries

### DIFF
--- a/src/main/java/orbis/analysis/NIDAnalyzer.java
+++ b/src/main/java/orbis/analysis/NIDAnalyzer.java
@@ -12,6 +12,7 @@ import ghidra.program.model.listing.*;
 import ghidra.program.model.symbol.*;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.exception.InvalidInputException;
+import ghidra.util.Msg;
 import ghidra.util.task.TaskMonitor;
 
 import orbis.util.OrbisUtil;
@@ -104,10 +105,12 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 					return;
 				}
 			}
+			String origName = name;
 			name = name.substring(0, 11);
 			if (db.containsKey(name)) {
 				name = db.get(name);
 			}
+			Msg.info(this, "NIDAnalyzer: Resolving symbol NID. Original name: " + origName + " -> Library: " + (ns != null ? ns.getName() : "Global") + ", Resolved name: " + name);
 			if (ns == null) {
 				ns = s.getProgram().getGlobalNamespace();
 			}

--- a/src/main/java/orbis/elf/OrbisElfExtension.java
+++ b/src/main/java/orbis/elf/OrbisElfExtension.java
@@ -17,6 +17,7 @@ import ghidra.program.model.mem.Memory;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.program.model.scalar.Scalar;
 import ghidra.program.model.symbol.*;
+import ghidra.util.Msg;
 import ghidra.util.exception.AssertException;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.exception.InvalidInputException;
@@ -313,6 +314,7 @@ public class OrbisElfExtension extends ElfExtension {
 			long offset =  value & 0xffffffffL;
 			long id = value >> 48;
 			String libName = stringTable.readString(reader, offset) + PRX_LIB_EXTENSION;
+			Msg.info(this, "OrbisElfExtension: Registered Import Library. ID: " + id + " -> " + libName);
 			man.addLibrary(libName, id);
 		}
 	}
@@ -373,30 +375,79 @@ public class OrbisElfExtension extends ElfExtension {
 		ElfProgramHeader[] phdrs = elf.getProgramHeaders(ElfProgramHeaderConstants.PT_GNU_EH_FRAME);
 		if (phdrs != null && phdrs.length == 1) {
 			try {
-				ElfProgramHeader phdr = phdrs[0];
-				Address addr = helper.getDefaultAddress(phdr.getVirtualAddress());
+				Address addr = helper.getDefaultAddress(phdrs[0].getVirtualAddress());
+				Msg.info(this, "OrbisElfExtension: fixing eh_frame_hdr at address " + addr);
 				Memory mem = program.getMemory();
 				MemoryBlock block = mem.getBlock(addr);
-				mem.split(block, addr);
-				block = mem.getBlock(addr);
-				block.setName(EH_FRAME_HDR);
-				Listing listing = program.getListing();
-				ProgramModule root = listing.getDefaultRootModule();
-				ProgramFragment fragment = root.createFragment(EH_FRAME_HDR);
-				fragment.move(block.getStart(), block.getEnd());
-				EhFrameHeaderSection section = new EhFrameHeaderSection(program);
-				section.analyze(monitor);
-				Reference[] refs = listing.getDataAfter(addr).getReferencesFrom();
-				if (refs != null && refs.length == 1) {
-					addr = refs[0].getToAddress();
-					block = mem.getBlock(addr);
-					mem.split(block, addr);
-					block = mem.getBlock(addr);
-					block.setName(EH_FRAME);
-					fragment = root.createFragment(EH_FRAME);
-					fragment.move(block.getStart(), block.getEnd());
+				if (block != null) {
+					if (addr.compareTo(block.getStart()) > 0 && addr.compareTo(block.getEnd()) < 0) {
+						mem.split(block, addr);
+						block = mem.getBlock(addr);
+					}
+					block.setName(EH_FRAME_HDR);
+					Listing listing = program.getListing();
+					ProgramModule root = listing.getDefaultRootModule();
+					if (root != null) {
+						ProgramFragment fragment = null;
+						for (String treeName : listing.getTreeNames()) {
+							fragment = listing.getFragment(treeName, EH_FRAME_HDR);
+							if (fragment != null) {
+								break;
+							}
+						}
+						if (fragment == null) {
+							try {
+								fragment = root.createFragment(EH_FRAME_HDR);
+							} catch (Exception e) {
+								Msg.warn(this, "OrbisElfExtension: failed to create fragment " + EH_FRAME_HDR + ": " + e.getMessage());
+							}
+						}
+						if (fragment != null) {
+							fragment.move(block.getStart(), block.getEnd());
+						}
+					}
+					
+					EhFrameHeaderSection section = new EhFrameHeaderSection(program);
+					section.analyze(monitor);
+					
+					Data data = listing.getDataAfter(addr);
+					if (data != null) {
+						Reference[] refs = data.getReferencesFrom();
+						if (refs != null && refs.length == 1) {
+							addr = refs[0].getToAddress();
+							Msg.info(this, "OrbisElfExtension: fixing eh_frame referenced from eh_frame_hdr at address " + addr);
+							block = mem.getBlock(addr);
+							if (block != null) {
+								if (addr.compareTo(block.getStart()) > 0 && addr.compareTo(block.getEnd()) < 0) {
+									mem.split(block, addr);
+									block = mem.getBlock(addr);
+								}
+								block.setName(EH_FRAME);
+								if (root != null) {
+									ProgramFragment fragment = null;
+									for (String treeName : listing.getTreeNames()) {
+										fragment = listing.getFragment(treeName, EH_FRAME);
+										if (fragment != null) {
+											break;
+										}
+									}
+									if (fragment == null) {
+										try {
+											fragment = root.createFragment(EH_FRAME);
+										} catch (Exception e) {
+											Msg.warn(this, "OrbisElfExtension: failed to create fragment " + EH_FRAME + ": " + e.getMessage());
+										}
+									}
+									if (fragment != null) {
+										fragment.move(block.getStart(), block.getEnd());
+									}
+								}
+							}
+						}
+					}
 				}
 			} catch (Exception e) {
+				Msg.error(this, "OrbisElfExtension: error in fixEhFrame", e);
 				helper.log(e);
 			}
 		}

--- a/src/main/java/orbis/elf/OrbisElfHeader.java
+++ b/src/main/java/orbis/elf/OrbisElfHeader.java
@@ -63,6 +63,10 @@ public class OrbisElfHeader extends ElfHeader {
 			invoke("parseGNU_r");
 		} else {
 			parseDynamicTable();
+			parseDynamicStringTable();
+			parseDynamicLibraryNames();
+			parseDynamicSymbolTable();
+			parseRelocationTables();
 		}
 	}
 
@@ -266,6 +270,7 @@ public class OrbisElfHeader extends ElfHeader {
 			ElfRelocationTable relocTable = createElfRelocationTable(getReader(),
 				this, null, fileOffset, addrOffset, tableSize, tableEntrySize,
 				addendTypeReloc, dynamicSymbolTable, null, TableFormat.DEFAULT);
+			Msg.info(this, "OrbisElfHeader: Parsed Relocation Table (" + relocTableAddrType.name + "). FileOffset: 0x" + Long.toHexString(fileOffset) + ", AddrOffset: 0x" + Long.toHexString(addrOffset) + ", Size: " + tableSize + ", EntrySize: " + tableEntrySize);
 			relocationTableList.add(relocTable);
 		}
 		catch (NotFoundException e) {
@@ -327,6 +332,9 @@ public class OrbisElfHeader extends ElfHeader {
 	}
 
 	public void parseDynamicStringTable() throws IOException {
+		if (getDynamicStringTable() != null) {
+			return;
+		}
 		List<ElfStringTable> tables = new ArrayList<>(List.of(getStringTables()));
 		ElfProgramHeader phdr = getDynlibData();
 		ElfDynamicTable dynamicTable = getDynamicTable();
@@ -359,6 +367,7 @@ public class OrbisElfHeader extends ElfHeader {
 				return;
 			}
 			ElfStringTable tbl = new ElfStringTable(this, null, fileOffset, addrOffset, stringTableSize);
+			Msg.info(this, "OrbisElfHeader: Parsed Dynamic String Table. FileOffset: 0x" + Long.toHexString(fileOffset) + ", AddrOffset: 0x" + Long.toHexString(addrOffset) + ", Size: " + stringTableSize);
 			setDynamicStringTable(tbl);
 			tables.add(tbl);
 			setStringTables(tables.toArray(ElfStringTable[]::new));
@@ -368,6 +377,9 @@ public class OrbisElfHeader extends ElfHeader {
 	}
 
 	public void parseDynamicSymbolTable() throws IOException {
+		if (getDynamicSymbolTable() != null) {
+			return;
+		}
 		List<ElfSymbolTable> tables = new ArrayList<>(List.of(getSymbolTables()));
 		ElfDynamicTable dynamicTable = getDynamicTable();
 		ElfStringTable dynamicStringTable = getDynamicStringTable();
@@ -417,6 +429,7 @@ public class OrbisElfHeader extends ElfHeader {
 			ElfSymbolTable tbl = new ElfSymbolTable(
 				reader, this, null, fileOffset, addrOffset,
 				tableSize, tableEntrySize, dynamicStringTable, null, true);
+			Msg.info(this, "OrbisElfHeader: Parsed Dynamic Symbol Table. FileOffset: 0x" + Long.toHexString(fileOffset) + ", AddrOffset: 0x" + Long.toHexString(addrOffset) + ", Size: " + tableSize + ", EntrySize: " + tableEntrySize);
 			setDynamicSymbolTable(tbl);
 			tables.add(tbl);
 			setSymbolTables(tables.toArray(ElfSymbolTable[]::new));

--- a/src/main/java/orbis/elf/blockmaker/ProgramReadOnlyBlockMaker.java
+++ b/src/main/java/orbis/elf/blockmaker/ProgramReadOnlyBlockMaker.java
@@ -11,6 +11,7 @@ import ghidra.program.model.mem.Memory;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.program.model.symbol.Symbol;
 import ghidra.program.model.symbol.SymbolTable;
+import ghidra.util.Msg;
 import ghidra.util.task.TaskMonitor;
 
 public class ProgramReadOnlyBlockMaker extends ReadOnlyBlockMaker {
@@ -34,6 +35,10 @@ public class ProgramReadOnlyBlockMaker extends ReadOnlyBlockMaker {
 	@Override
 	public void makeBlock() throws Exception {
 		ProgramFragment frag = getPltGotFragment();
+		if (frag == null) {
+			Msg.warn(this, "ProgramReadOnlyBlockMaker: .got.plt fragment is null!");
+			return;
+		}
 		Address addr = frag.getMinAddress();
 		if (addr != null) {
 			monitor.setMessage("Scanning .got.plt");
@@ -51,6 +56,10 @@ public class ProgramReadOnlyBlockMaker extends ReadOnlyBlockMaker {
 
 	void createPltGotFragment(Address start) throws Exception {
 		ProgramFragment frag = getPltGotFragment();
+		if (frag == null) {
+			Msg.warn(this, "ProgramReadOnlyBlockMaker: .got.plt fragment is null in createPltGotFragment!");
+			return;
+		}
 		Program program = getProgram();
 		Memory mem = program.getMemory();
 		Address addr = start;
@@ -73,6 +82,10 @@ public class ProgramReadOnlyBlockMaker extends ReadOnlyBlockMaker {
 		monitor.setMessage("Finding trampolines");
 		JumpSearcher searcher = new JumpSearcher(program, monitor);
 		ProgramFragment frag = getPltGotFragment();
+		if (frag == null) {
+			Msg.warn(this, "ProgramReadOnlyBlockMaker: .got.plt fragment is null in createTrampolines!");
+			return null;
+		}
 		if (frag.getMinAddress() == null) {
 			SymbolTable st = program.getSymbolTable();
 			List<Symbol> syms = st.getGlobalSymbols("_DT_FINI");
@@ -87,7 +100,7 @@ public class ProgramReadOnlyBlockMaker extends ReadOnlyBlockMaker {
 			if (frag.getMinAddress() == null) {
 				createPltGotFragment(addr);
 			}
-			if (frag.contains(addr)) {
+			if (frag.getMinAddress() != null && frag.contains(addr)) {
 				break;
 			}
 		}
@@ -128,8 +141,13 @@ public class ProgramReadOnlyBlockMaker extends ReadOnlyBlockMaker {
 			this.mem = program.getMemory();
 			this.monitor = monitor;
 			MemoryBlock block = mem.getBlock(".text");
-			this.address = block.getStart();
-			this.end = block.getEnd();
+			if (block != null) {
+				this.address = block.getStart();
+				this.end = block.getEnd();
+			} else {
+				this.address = null;
+				this.end = null;
+			}
 		}
 
 		boolean isJump() throws Exception {
@@ -154,12 +172,17 @@ public class ProgramReadOnlyBlockMaker extends ReadOnlyBlockMaker {
 		}
 
 		Address getNextAddress() {
-			if (address == null) {
+			if (address == null || end == null) {
 				return null;
 			}
 			do {
+				Address nextAddr = address.next();
+				if (nextAddr == null) {
+					address = null;
+					break;
+				}
 				address = mem.findBytes(
-					address.next(), end, JMP_BYTES, JMP_MASK, true, monitor);
+					nextAddr, end, JMP_BYTES, JMP_MASK, true, monitor);
 			} while (address != null && address.getOffset() % 8 != 0);
 			return address;
 		}

--- a/src/main/java/orbis/elf/blockmaker/ReadOnlyBlockMaker.java
+++ b/src/main/java/orbis/elf/blockmaker/ReadOnlyBlockMaker.java
@@ -5,6 +5,7 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.mem.Memory;
 import ghidra.program.model.mem.MemoryBlock;
+import ghidra.util.Msg;
 import ghidra.util.task.TaskMonitor;
 
 public abstract class ReadOnlyBlockMaker {
@@ -28,10 +29,27 @@ public abstract class ReadOnlyBlockMaker {
 	protected ProgramFragment getFragment(String name) throws Exception {
 		Listing listing = getProgram().getListing();
 		ProgramModule root = listing.getDefaultRootModule();
-		ProgramFragment frag = listing.getFragment(root.getTreeName(), name);
-		if (frag == null) {
-			frag = root.createFragment(name);
+		if (root == null) {
+			Msg.warn(this, "ReadOnlyBlockMaker: root module is null while looking for fragment " + name);
+			return null;
 		}
+		
+		// 1. Search in all trees first
+		ProgramFragment frag = null;
+		for (String treeName : listing.getTreeNames()) {
+			frag = listing.getFragment(treeName, name);
+			if (frag != null) {
+				return frag;
+			}
+		}
+		
+		// 2. Try creating it in the root module
+		try {
+			frag = root.createFragment(name);
+		} catch (Exception e) {
+			Msg.error(this, "ReadOnlyBlockMaker: failed to create fragment " + name + ": " + e.getMessage(), e);
+		}
+		
 		return frag;
 	}
 
@@ -39,12 +57,22 @@ public abstract class ReadOnlyBlockMaker {
 		Program program = getProgram();
 		Memory mem = program.getMemory();
 		MemoryBlock block = mem.getBlock(addr);
-		mem.split(block, addr);
-		block = mem.getBlock(addr);
-		block.setName(RO_DATA_BLOCK_NAME);
-		block.setExecute(false);
-		block.setWrite(false);
-		ProgramFragment frag = getFragment(RO_DATA_BLOCK_NAME);
-		frag.move(block.getStart(), block.getEnd());
+		if (block != null) {
+			if (addr.compareTo(block.getStart()) > 0 && addr.compareTo(block.getEnd()) < 0) {
+				try {
+					mem.split(block, addr);
+					block = mem.getBlock(addr);
+				} catch (Exception e) {
+					Msg.error(this, "ReadOnlyBlockMaker: failed to split memory block: " + e.getMessage(), e);
+				}
+			}
+			block.setName(RO_DATA_BLOCK_NAME);
+			block.setExecute(false);
+			block.setWrite(false);
+			ProgramFragment frag = getFragment(RO_DATA_BLOCK_NAME);
+			if (frag != null) {
+				frag.move(block.getStart(), block.getEnd());
+			}
+		}
 	}
 }


### PR DESCRIPTION
This Pull Request addresses several crashes, null pointer exceptions, and symbol/import resolution issues when loading PS4 retail or stripped binaries (such as `eboot.bin` / `eboot.elf`) that lack standard ELF Section Headers.

### Key Changes:

1. **ELF Parse Path (`OrbisElfHeader.java`)**
   - Enabled parsing of dynamic string tables (`parseDynamicStringTable()`), symbol tables (`parseDynamicSymbolTable()`), and relocation tables (`parseRelocationTables()`) for non-kernel ELFs. Previously, these were completely skipped for non-kernel binaries, leading to unresolved external libraries (`UNK_LIB_NAME_X`).
   - Added guards to `parseDynamicStringTable()` and `parseDynamicSymbolTable()` to check if they are already loaded, preventing duplicate table registrations and subsequent `Conflicting data exists` errors.

2. **Safe Memory Block Splitting (`OrbisElfExtension.java` & `ReadOnlyBlockMaker.java`)**
   - Added boundaries and validation checks to `fixEhFrame` and `createReadOnlyBlock` before splitting memory blocks. This avoids `IllegalArgumentException` ("Blocks do not belong to this program") thrown by Ghidra's API when splitting precisely at block boundaries.

3. **Robust Fragment & Program Tree Handling (`ReadOnlyBlockMaker.java` & `ProgramReadOnlyBlockMaker.java`)**
   - Updated `getFragment()` to search for named fragments across all program trees instead of assuming the default tree name.
   - Added null-checks on returned program fragments within PLT/GOT processing, trampolines, and memory block creation to prevent `NullPointerException` on stripped binaries.
   - Added bounds checking in the segment scanner to prevent out-of-bounds address increments.

4. **NID Diagnostics (`NIDAnalyzer.java`)**
   - Added info-level logs to output mapped library names and resolved symbol info to aid in future diagnostics.

made with the help of Gemini
