### PR TITLE
fix: add null check for function after CreateFunctionCmd

### DIFF
--- a/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
+++ b/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
@@ -65,10 +65,11 @@ public class StackChkFailAnalyzer extends AbstractKernelAnalyzer {
 		address = addresses.iterator().next().subtract(pointerSize);
 		Address stackCheckFailAddress = getAbsoluteAddress(program, address);
 		if (stackCheckFailAddress == null) {
-		    log.appendMsg(getName(), "Failed to read __stack_chk_fail pointer at " + address + " this should not occur.");
-		    return true;   
+			log.appendMsg(getName(),
+				"Failed to read __stack_chk_fail pointer at " + address + " this should not occur.");
+			return true;
 		}
-		return defineFunction(program, address, log);
+		return defineFunction(program, stackCheckFailAddress, log);
 	}
 
 	private static boolean defineFunction(Program program, Address address, MessageLog log) {

--- a/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
+++ b/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
@@ -77,6 +77,10 @@ public class StackChkFailAnalyzer extends AbstractKernelAnalyzer {
 				cmd.applyTo(program);
 				function = cmd.getFunction();
 			}
+			if (function == null) {
+				log.appendMsg(getName(), "Failed to create or find function at " + address);
+				return false;
+			}
 			function.setName(FUNCTION_NAME, SourceType.IMPORTED);
 			function.setReturnType(VoidDataType.dataType, SourceType.IMPORTED);
 			function.setCallingConvention(CompilerSpec.CALLING_CONVENTION_stdcall);

--- a/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
+++ b/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
@@ -68,6 +68,11 @@ public class StackChkFailAnalyzer extends AbstractKernelAnalyzer {
 	}
 
 	private static boolean defineFunction(Program program, Address address, MessageLog log) {
+		if (address == null) {
+			log.appendMsg(getName(),
+				"Could not resolve absolute address for __stack_chk_fail");
+			return true; // not a failure, just not found
+		}
 		try {
 			FunctionManager man = program.getFunctionManager();
 			Function function = man.getFunctionAt(address);

--- a/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
+++ b/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
@@ -63,7 +63,11 @@ public class StackChkFailAnalyzer extends AbstractKernelAnalyzer {
 			return true;
 		}
 		address = addresses.iterator().next().subtract(pointerSize);
-		address = getAbsoluteAddress(program, address);
+		Address stackCheckFailAddress = getAbsoluteAddress(program, address);
+		if (stackCheckFailAddress == null) {
+		    log.appendMsg(getName(), "Failed to read __stack_chk_fail pointer at " + address + " this should not occur.");
+		    return true;   
+		}
 		return defineFunction(program, address, log);
 	}
 

--- a/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
+++ b/src/main/java/orbis/analysis/StackChkFailAnalyzer.java
@@ -83,7 +83,20 @@ public class StackChkFailAnalyzer extends AbstractKernelAnalyzer {
 				function = cmd.getFunction();
 			}
 			if (function == null) {
-				log.appendMsg(getName(), "Failed to create or find function at " + address);
+				MemoryBlock block = program.getMemory().getBlock(address);
+				if (block == null) {
+					log.appendMsg(getName(),
+						"Failed to create function at " + address +
+						" (address not in any memory block)");
+				} else if (!block.isExecute()) {
+					log.appendMsg(getName(),
+						"Failed to create function at " + address +
+						" in non-executable block: " + block.getName());
+				} else {
+					log.appendMsg(getName(),
+						"Failed to create function at " + address +
+						" in executable block: " + block.getName() + " (unexpected)");
+				}
 				return false;
 			}
 			function.setName(FUNCTION_NAME, SourceType.IMPORTED);


### PR DESCRIPTION
CreateFunctionCmd.getFunction() can return null when it fails. Add null check to prevent NPE on setName().

Fixes #28